### PR TITLE
Update cmdline

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -44,6 +44,7 @@ static void remove_safetynet_flags(char *cmd)
 	remove_flag(cmd, "androidboot.secboot=");
 	remove_flag(cmd, "androidboot.verifiedbootstate=");
 	remove_flag(cmd, "androidboot.veritymode=");
+	remove_flag(cmd, "androidboot.warranty_bit=");
 }
 
 static int __init proc_cmdline_init(void)


### PR DESCRIPTION
This addition allows kernel to boot without warranty bit set 0x1 rather to unknown (Fake knox) instead of using root method. I can now use "private mode" within sbrowser for example without rooting.